### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/CreateRepositoryMojo.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/CreateRepositoryMojo.java
@@ -131,7 +131,7 @@ public class CreateRepositoryMojo
         // Initialize
         // -----------------------------------------------------------------------
 
-        StringBuffer path = new StringBuffer( "file://" + assembleDirectory.getAbsolutePath() + "/" );
+        StringBuilder path = new StringBuilder( "file://" + assembleDirectory.getAbsolutePath() + "/" );
 
         path.append( repositoryName );
 

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
@@ -89,7 +89,7 @@ public class DefaultScriptGenerator
             getLogger().debug( "Using license file: " + daemon.getLicenseHeaderFile() );
             lines = readLicenseHeaderFromFile( new File( daemon.getLicenseHeaderFile() ) );
         }
-        StringBuffer resultLines = new StringBuffer();
+        StringBuilder resultLines = new StringBuilder();
         for ( int i = 0; i < lines.size(); i++ )
         {
             String licenseLine = platform.getCommentPrefix() + lines.get( i );

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/Platform.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/Platform.java
@@ -285,7 +285,7 @@ public class Platform
     {
         List<ClasspathElement> classpath = daemon.getAllClasspathElements();
 
-        StringBuffer classpathBuffer = new StringBuffer();
+        StringBuilder classpathBuffer = new StringBuilder();
 
         for ( ClasspathElement classpathElement : classpath )
         {

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/repository/FlatRepositoryLayout.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/repository/FlatRepositoryLayout.java
@@ -49,7 +49,7 @@ public class FlatRepositoryLayout
     {
         ArtifactHandler artifactHandler = artifact.getArtifactHandler();
 
-        StringBuffer path = new StringBuffer();
+        StringBuilder path = new StringBuilder();
 
         path.append( artifact.getArtifactId() ).append( ARTIFACT_SEPARATOR ).append( artifact.getVersion() );
 
@@ -73,7 +73,7 @@ public class FlatRepositoryLayout
 
     private String pathOfRepositoryMetadata( String filename )
     {
-        StringBuffer path = new StringBuffer();
+        StringBuilder path = new StringBuilder();
 
         path.append( filename );
 

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/ArtifactUtils.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/ArtifactUtils.java
@@ -48,7 +48,7 @@ public final class ArtifactUtils
     {
         ArtifactHandler artifactHandler = artifact.getArtifactHandler();
 
-        StringBuffer fileName = new StringBuffer();
+        StringBuilder fileName = new StringBuilder();
 
         fileName.append( artifact.getArtifactId() ).append( "-" ).append( artifact.getBaseVersion() );
 
@@ -66,7 +66,7 @@ public final class ArtifactUtils
         String[] tokens = StringUtils.split( relativePath, "/" );
         tokens[tokens.length - 1] = fileName.toString();
 
-        StringBuffer path = new StringBuffer();
+        StringBuilder path = new StringBuilder();
 
         for ( int i = 0; i < tokens.length; ++i )
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed