### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used.

### DIFF
--- a/appassembler-booter/src/main/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooter.java
+++ b/appassembler-booter/src/main/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooter.java
@@ -187,7 +187,7 @@ public class AppassemblerBooter
         try
         {
             AppassemblerModelStaxReader reader = new AppassemblerModelStaxReader();
-            return reader.read( new InputStreamReader( resource ) );
+            return reader.read( new InputStreamReader( resource, "UTF-8" ) );
         }
         finally
         {

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/daemontools/DaemonToolsDaemonGenerator.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/daemontools/DaemonToolsDaemonGenerator.java
@@ -141,7 +141,7 @@ public class DaemonToolsDaemonGenerator
 
         try
         {
-            envReader = new InputStreamReader( this.getClass().getResourceAsStream( "env/" + envName ) );
+            envReader = new InputStreamReader( this.getClass().getResourceAsStream( "env/" + envName ), "UTF-8");
 
             // -----------------------------------------------------------------------
             // Write the file

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
@@ -169,7 +169,7 @@ public class DefaultScriptGenerator
         {
             in = getScriptTemplate( platformName, daemon );
 
-            InputStreamReader reader = new InputStreamReader( getScriptTemplate( platformName, daemon ) );
+            InputStreamReader reader = new InputStreamReader( getScriptTemplate( platformName, daemon ), "UTF-8" );
 
             Map<Object, Object> context = new HashMap<Object, Object>();
             context.put( "MAINCLASS", daemon.getMainClass() );

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/FormattedProperties.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/FormattedProperties.java
@@ -140,7 +140,7 @@ public class FormattedProperties
             fileLines = new ArrayList<String>();
             propertyLines = new HashMap<String, Integer>();
 
-            BufferedReader r = new BufferedReader( new InputStreamReader( inputStream ) );
+            BufferedReader r = new BufferedReader( new InputStreamReader( inputStream, "UTF-8") );
 
             try
             {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed