### PR TITLE
Code quality fix - JUnit framework methods should be declared properly.

### DIFF
--- a/appassembler-booter/src/test/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooterTest.java
+++ b/appassembler-booter/src/test/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooterTest.java
@@ -34,7 +34,7 @@ import junit.framework.TestCase;
 public class AppassemblerBooterTest
     extends TestCase
 {
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();

--- a/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/daemon/script/ScriptGeneratorBackgroundTest.java
+++ b/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/daemon/script/ScriptGeneratorBackgroundTest.java
@@ -38,7 +38,7 @@ public class ScriptGeneratorBackgroundTest
 {
     private static final String PREFIX = "src/test/resources/org/codehaus/mojo/appassembler/daemon/script/background/";
 
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();

--- a/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/daemon/script/ScriptGeneratorBaseDirRepoTest.java
+++ b/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/daemon/script/ScriptGeneratorBaseDirRepoTest.java
@@ -40,7 +40,7 @@ public class ScriptGeneratorBaseDirRepoTest
     private static final String PREFIX =
         "src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/";
 
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();

--- a/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/daemon/script/ScriptGeneratorTest.java
+++ b/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/daemon/script/ScriptGeneratorTest.java
@@ -39,7 +39,7 @@ public class ScriptGeneratorTest
 {
     private static final String PREFIX = "src/test/resources/org/codehaus/mojo/appassembler/daemon/script/";
 
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();

--- a/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/util/FormattedPropertiesTest.java
+++ b/appassembler-maven-plugin/src/test/java/org/codehaus/mojo/appassembler/util/FormattedPropertiesTest.java
@@ -34,7 +34,7 @@ public class FormattedPropertiesTest
 {
     private FormattedProperties formattedProperties;
 
-    protected void setUp()
+    public void setUp()
         throws Exception
     {
         super.setUp();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2391 -  JUnit framework methods should be declared properly.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2391

Please let me know if you have any questions.

Faisal Hameed