### PR TITLE
General code quality fix-1

### DIFF
--- a/appassembler-booter/src/main/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooter.java
+++ b/appassembler-booter/src/main/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooter.java
@@ -51,6 +51,11 @@ import org.codehaus.mojo.appassembler.model.io.stax.AppassemblerModelStaxReader;
  */
 public class AppassemblerBooter
 {
+    private AppassemblerBooter() 
+    {
+        
+    }
+    
     private static boolean debug;
 
     private static Daemon config;

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/merge/DefaultDaemonMerger.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/merge/DefaultDaemonMerger.java
@@ -99,7 +99,7 @@ public class DefaultDaemonMerger
 
         // TODO: The above is not possible as long as the modello generated stuff returns an empty list on not set
         // fields.
-        if ( dominant != null && dominant.size() > 0 )
+        if ( dominant != null && !dominant.isEmpty() )
         {
             return dominant;
         }

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/Platform.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/Platform.java
@@ -419,7 +419,7 @@ public class Platform
     {
         List<String> commandLineArguments = convertArguments( descriptor.getCommandLineArguments() );
 
-        if ( commandLineArguments == null || commandLineArguments.size() == 0 )
+        if ( commandLineArguments == null || commandLineArguments.isEmpty() )
         {
             return null;
         }

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/DependencyFactory.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/DependencyFactory.java
@@ -42,6 +42,11 @@ import org.codehaus.plexus.util.StringUtils;
  */
 public class DependencyFactory
 {
+    private DependencyFactory() 
+    {
+        
+    }
+    
     /**
      * Used by GenericDaemonGenerator.
      */

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/FileFilterHelper.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/util/FileFilterHelper.java
@@ -35,6 +35,11 @@ import org.apache.commons.io.filefilter.RegexFileFilter;
  */
 public class FileFilterHelper
 {
+    private FileFilterHelper()
+    {
+        
+    }
+    
     /**
      * Make the given IOFileFilter aware of directories.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1118 - Utility classes should not have public constructors.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1155
 
Please let me know if you have any questions.

Faisal Hameed