### PR TITLE
General code quality fix-2

### DIFF
--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/AbstractAppAssemblerMojo.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/AbstractAppAssemblerMojo.java
@@ -137,7 +137,7 @@ public abstract class AbstractAppAssemblerMojo
     {
         try
         {
-            ArtifactRepositoryLayout artifactRepositoryLayout = null;
+            ArtifactRepositoryLayout artifactRepositoryLayout;
             artifactRepositoryLayout =
                 (ArtifactRepositoryLayout) container.lookup( "org.apache.maven.artifact."
                     + "repository.layout.ArtifactRepositoryLayout", repositoryLayout );

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/AssembleMojo.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/AssembleMojo.java
@@ -478,7 +478,7 @@ public class AssembleMojo
         throws MojoFailureException
     {
         // create (if necessary) directory for bin files
-        File binDir = new File( assembleDirectory.getAbsolutePath(), binFolder.toString() );
+        File binDir = new File( assembleDirectory.getAbsolutePath(), binFolder );
 
         if ( !binDir.exists() )
         {

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/CreateRepositoryMojo.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/CreateRepositoryMojo.java
@@ -180,7 +180,7 @@ public class CreateRepositoryMojo
             ArtifactFilter filter = new ExcludesArtifactFilter( Collections.singletonList( "junit:junit" ) );
             ArtifactResolutionResult result =
                 artifactResolver.resolveTransitively( Collections.singleton( artifact ), p, localRepository,
-                                                      Collections.EMPTY_LIST, metadataSource, filter );
+                                                      Collections.emptyList(), metadataSource, filter );
             for ( Iterator i = result.getArtifacts().iterator(); i.hasNext(); )
             {
                 Artifact a = (Artifact) i.next();

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
@@ -78,7 +78,7 @@ public class DefaultScriptGenerator
     private String getLicenseHeader( Platform platform, Daemon daemon )
         throws DaemonGeneratorException
     {
-        List<String> lines = null;
+        List<String> lines;
         if ( isDefaultLicenseHeaderRequested( daemon ) )
         {
             getLogger().debug( "Using default licence file (" + DEFAULT_LICENSE_HEADER + ")." );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1854 - Dead stores should be removed.
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of 
Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET. 
squid:S1858 -  "toString()" should never be called on a String object.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1596
https://dev.eclipse.org/sonar/rules/show/squid:S1858

Please let me know if you have any questions.

Faisal Hameed