### PR TITLE
Added showConsoleWindow to program definition.

### DIFF
--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/AssembleMojo.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/AssembleMojo.java
@@ -356,7 +356,7 @@ public class AssembleMojo
             daemon.setId( program.getName() );
         }
         daemon.setMainClass( program.getMainClass() );
-        daemon.setShowConsoleWindow( showConsoleWindow );
+        daemon.setShowConsoleWindow( program.getShowConsoleWindow() != null ? program.getShowConsoleWindow() : showConsoleWindow );
         daemon.setCommandLineArguments( program.getCommandLineArguments() );
 
         if ( program.getLicenseHeaderFile() != null )

--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/Program.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/Program.java
@@ -81,6 +81,13 @@ public class Program
     private Set<String> platforms;
 
     /**
+     * Show console window when execute this application. When false, the generated java command runs in background.
+     * This works best for Swing application where the command line invocation is not blocked.
+     */
+    @Parameter
+    private Boolean showConsoleWindow;
+
+    /**
      * The default constructor.
      */
     public Program()
@@ -270,6 +277,24 @@ public class Program
     public void setBinFolder( File binFolder )
     {
         this.binFolder = binFolder;
+    }
+
+    /**
+     * Should show console window.
+     *
+     * @return If console window should be shown.
+     */
+    public Boolean getShowConsoleWindow() {
+      return showConsoleWindow;
+    }
+
+    /**
+     * Set show console window.
+     *
+     * @param showConsoleWindow Console window shown.
+     */
+    public void setShowConsoleWindow(Boolean showConsoleWindow) {
+      this.showConsoleWindow = showConsoleWindow;
     }
 
 }


### PR DESCRIPTION
Hello first time contributing.

I have a usage case where I need showConsoleWindow to not be global so I prupose this change. For backwards compatibility I left the showConsoleWindow parameter as global and made it so that program specific config has precedence.
