### PR TITLE
Issue [#48]

### DIFF
--- a/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/unixBinTemplate
+++ b/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/unixBinTemplate
@@ -99,7 +99,7 @@ if $cygwin; then
   [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
 fi
 
-exec "$JAVACMD" $JAVA_OPTS @EXTRA_JVM_ARGUMENTS@ \
+exec "$JAVACMD" @EXTRA_JVM_ARGUMENTS@ $JAVA_OPTS \
   -classpath "$CLASSPATH" \
   -Dapp.name="@APP_NAME@" \
   -Dapp.pid="$$" \


### PR DESCRIPTION
[#48] just swap `$JAVA_OPTS` and `@EXTRA_JVM_ARGUMENTS@` so env is last and has a chance for its values to take precedence

(I tested this works for me using [`<unixScriptTemplate>`](http://www.mojohaus.org/appassembler/appassembler-maven-plugin/assemble-mojo.html#unixScriptTemplate) configuration option suggested in http://stackoverflow.com/a/27608001/689119)