### PR TITLE
Don't minimize window when hiding console

### DIFF
--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/DefaultScriptGenerator.java
@@ -204,7 +204,7 @@ public class DefaultScriptGenerator
             }
             else
             {
-                context.put( "JAVA_BINARY", "start /min javaw" );
+                context.put( "JAVA_BINARY", "start javaw" );
                 context.put( "UNIX_BACKGROUND", " &" );
             }
 


### PR DESCRIPTION
Wasn't a problem with Swing, but caused JavaFx window to be minimized on start.

Fixes #64 