### PR TITLE
Fix an issue whereby System Properties were not interpolated for generate-daemons

### DIFF
--- a/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/Platform.java
+++ b/appassembler-maven-plugin/src/main/java/org/codehaus/mojo/appassembler/daemon/script/Platform.java
@@ -382,7 +382,7 @@ public class Platform
         vmArgs = addJvmSetting( "-Xss", jvmSettings.getMaxStackSize(), vmArgs );
 
         vmArgs += arrayToString( convertArguments( jvmSettings.getExtraArguments() ), "" );
-        vmArgs += arrayToString( jvmSettings.getSystemProperties(), "-D" );
+        vmArgs += arrayToString( convertArguments( jvmSettings.getSystemProperties() ), "-D" );
 
         return vmArgs.trim();
     }


### PR DESCRIPTION
Closes https://github.com/mojohaus/appassembler/issues/83

Previously System Properties were interpolated for `assemble` but not `generate-daemons`