### PR TITLE
Improve Windows batch file %BASEDIR% path generation

### DIFF
--- a/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/windowsBinTemplate
+++ b/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/windowsBinTemplate
@@ -44,7 +44,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
 :repoSetup
 set REPO=

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-basedir-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-basedir-test.bat
@@ -62,7 +62,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
 :repoSetup
 set REPO=

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-repo-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-repo-test.bat
@@ -62,7 +62,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
 :repoSetup
 set REPO=

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/background/expected-false-showConsoleWindow-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/background/expected-false-showConsoleWindow-test.bat
@@ -62,7 +62,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
 :repoSetup
 set REPO=

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test-endorsed-lib.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test-endorsed-lib.bat
@@ -62,7 +62,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
 :repoSetup
 set REPO=

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test.bat
@@ -62,7 +62,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
 :repoSetup
 set REPO=


### PR DESCRIPTION
Closes https://github.com/mojohaus/appassembler/issues/85

This normalizes the path by resolving the `..` and removing the trailing `\` that was previously present.