### PR TITLE
Don't introduce quotes into parts of command line args

### DIFF
--- a/appassembler-booter/src/main/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooter.java
+++ b/appassembler-booter/src/main/java/org/codehaus/mojo/appassembler/booter/AppassemblerBooter.java
@@ -277,12 +277,12 @@ public class AppassemblerBooter
 
         final String baseDir = System.getProperty( "basedir", System.getProperty( "app.home" ) );
         if ( baseDir != null && baseDir.length() > 0) {
-            context.put( "BASEDIR", StringUtils.quoteAndEscape(baseDir, '"') );
+            context.put( "BASEDIR", baseDir );
         }
 
         final String repo = System.getProperty( "app.repo" );
         if ( repo != null && repo.length() > 0 ) {
-            context.put("REPO", StringUtils.quoteAndEscape(repo, '"'));
+            context.put("REPO", repo);
         }
 
         InterpolationFilterReader interpolationFilterReader = new InterpolationFilterReader( sr, context, "@", "@" );
@@ -294,6 +294,7 @@ public class AppassemblerBooter
         {
             // shouldn't happen...
         }
+
         return result.toString();
     }
 


### PR DESCRIPTION
Regression that was introduced as part of b472009

Stopped interpolation (`@BASEDIR@` and `@REPO@`) of command line args containing file paths from being constructed correctly.