### PR TITLE
Fixes #114 - Unquoted %JAVACMD% in Windows script

### DIFF
--- a/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/windowsBinTemplate
+++ b/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/windowsBinTemplate
@@ -64,7 +64,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% #EXTRA_JVM_ARGUMENTS# -classpath %CLASSPATH% -Dapp.name="#APP_NAME#" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" #MAINCLASS# #APP_ARGUMENTS#%CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% #EXTRA_JVM_ARGUMENTS# -classpath %CLASSPATH% -Dapp.name="#APP_NAME#" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" #MAINCLASS# #APP_ARGUMENTS#%CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 


### PR DESCRIPTION
This prevents the Windows script from crashing if %JAVACMD% contains whitespace.