### PR TITLE
Fix for Issue 49

### DIFF
--- a/appassembler-maven-plugin/pom.xml
+++ b/appassembler-maven-plugin/pom.xml
@@ -82,20 +82,24 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-core</artifactId>
       <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- This must come after maven-project, or else weird component lookup failures occur during test phase -->
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -107,6 +111,7 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
@@ -401,7 +406,6 @@
     <profile>
       <id>grid</id>
       <properties>
-        <invokerPluginVersion>1.6-SNAPSHOT</invokerPluginVersion>
         <itParallelThreads>1</itParallelThreads>
       </properties>
       <pluginRepositories>
@@ -422,14 +426,13 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>${invokerPluginVersion}</version>
+            <version>3.2.2</version>
             <configuration>
               <parallelThreads>${itParallelThreads}</parallelThreads>
             </configuration>
           </plugin>
           <plugin>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>1.0</version>
             <executions>
               <execution>
                 <id>mojo-enforcer-rules</id>

--- a/appassembler-model/pom.xml
+++ b/appassembler-model/pom.xml
@@ -71,7 +71,7 @@
       <plugin>
         <groupId>org.codehaus.modello</groupId>
         <artifactId>modello-maven-plugin</artifactId>
-        <version>1.8.1</version>
+        <version>1.11</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>mojo-parent</artifactId>
-    <version>39</version>
+    <version>61</version>
   </parent>
   <artifactId>appassembler</artifactId>
   <packaging>pom</packaging>
@@ -164,7 +164,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.13.2</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -204,6 +204,7 @@
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
+          <version>3.0.0-M1</version>
           <configuration>
             <!-- do not deploy site but use instructions in README.md -->
             <mavenExecutorId>forked-path</mavenExecutorId>
@@ -216,6 +217,16 @@
     </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-maven-plugin</artifactId>
+          <version>1.3.8</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M3</version>
+        </plugin>
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>


### PR DESCRIPTION
Fix for Issue #49

Upgraded mojo-parent to latest (61)
Explicit versions for plexus & enforcer plugins
Set provided scope for maven dependencies in appasembler-maven-plugin

Developed at #Javaland 2021 #Hackergarten along with
Co-authored-by: Paul Daus <paul.daus@email.de>
Co-authored-by: Markus <markus@headcrashing.eu>
Co-authored-by: Markus Fihlon <marcus@fihlon.swiss>