### PR TITLE
Make sure that templates and expected test result files for unix scri…

### DIFF
--- a/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/.gitattributes
+++ b/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+unixBinTemplate text eol=lf

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/.gitattributes
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+expected-basedir-test text eol=lf
+expected-repo-test text eol=lf

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/.gitattributes
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+expected-test text eol=lf
+expected-test-endorsed-lib text eol=lf

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/background/.gitattributes
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/background/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+expected-false-showConsoleWindow-test text eol=lf


### PR DESCRIPTION
…pts have the correct line endings. Without these settings tests will fail when run on Windows.