### PR TITLE
Fix problem with spaces in JAVACMD or CLASSPATH for windows batch scripts

### DIFF
--- a/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/windowsBinTemplate
+++ b/appassembler-maven-plugin/src/main/resources/org/codehaus/mojo/appassembler/daemon/script/windowsBinTemplate
@@ -64,7 +64,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% #EXTRA_JVM_ARGUMENTS# -classpath %CLASSPATH% -Dapp.name="#APP_NAME#" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" #MAINCLASS# #APP_ARGUMENTS#%CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% #EXTRA_JVM_ARGUMENTS# -classpath "%CLASSPATH%" -Dapp.name="#APP_NAME#" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" #MAINCLASS# #APP_ARGUMENTS#%CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/booter/app.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/booter/app.bat
@@ -78,7 +78,7 @@ goto endInit
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% %EXTRA_JVM_ARGUMENTS% -classpath %CLASSPATH_PREFIX%;%CLASSPATH% -Dapp.name="app" -Dapp.repo="%REPO%" -Dbasedir="%BASEDIR%" org.codehaus.mojo.appassembler.booter.AppassemblerBooter %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% %EXTRA_JVM_ARGUMENTS% -classpath "%CLASSPATH_PREFIX%";"%CLASSPATH%" -Dapp.name="app" -Dapp.repo="%REPO%" -Dbasedir="%BASEDIR%" org.codehaus.mojo.appassembler.booter.AppassemblerBooter %CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-basedir-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-basedir-test.bat
@@ -82,7 +82,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% Yo dude xyz="%BASEDIR%" -classpath %CLASSPATH% -Dapp.name="basedir-test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% Yo dude xyz="%BASEDIR%" -classpath "%CLASSPATH%" -Dapp.name="basedir-test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-repo-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script-basedir-repo/expected-repo-test.bat
@@ -82,7 +82,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% Yo dude xyz="%REPO%" -classpath %CLASSPATH% -Dapp.name="repo-test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% Yo dude xyz="%REPO%" -classpath "%CLASSPATH%" -Dapp.name="repo-test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/background/expected-false-showConsoleWindow-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/background/expected-false-showConsoleWindow-test.bat
@@ -82,7 +82,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% Yo dude -classpath %CLASSPATH% -Dapp.name="test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% Yo dude -classpath "%CLASSPATH%" -Dapp.name="test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test-endorsed-lib.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test-endorsed-lib.bat
@@ -82,7 +82,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% Yo dude -classpath %CLASSPATH% -Dapp.name="test-endorsed-lib" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% Yo dude -classpath "%CLASSPATH%" -Dapp.name="test-endorsed-lib" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test.bat
+++ b/appassembler-maven-plugin/src/test/resources/org/codehaus/mojo/appassembler/daemon/script/expected-test.bat
@@ -82,7 +82,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% Yo dude -classpath %CLASSPATH% -Dapp.name="test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS% Yo dude -classpath "%CLASSPATH%" -Dapp.name="test" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" foo.Bar %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 


### PR DESCRIPTION
This should resolve issue #114 .
In addition to the quoted `JAVACMD`, `CLASSPATH` is also quoted so that spaces in the classpath do not crash the batch script.
The test expectations have been updated accordingly.